### PR TITLE
Make engine be a required argument for builder()

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Install via npm.
 ```js
 'use strict';
 
-const builder = require( 'joi-json' ).builder();
+const joi = require( 'joi' );
+
+const builder = require( 'joi-json' ).builder( joi );
 
 let jsonSchema = {
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,9 @@
 ```js
 'use strict';
 
-const builder = require( 'joi-json' ).builder();
+const joi = require( 'joi' );
+
+const builder = require( 'joi-json' ).builder( joi );
 
 let jsonSchema = {
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -3,7 +3,7 @@
 const Joi = require( 'joi' );
 
 //const builder = require( 'joi-json' ).builder();
-const builder = require( '..' ).builder();
+const builder = require( '..' ).builder( Joi );
 
 let jsonSchema = {
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,21 +33,6 @@ class SchemaBuilder {
     }
 }
 
-function resolveEngines() {
-
-    for( let name of arguments ) {
-
-        try {
-
-            return require( name );
-        }
-        catch( err ) {
-
-            // engine not found
-        }
-    }
-}
-
 function parser( engine ) {
 
     return new Parser( engine );
@@ -56,14 +41,9 @@ function parser( engine ) {
 
 function builder( engine ) {
 
-    if( !engine ) {
+    if( !engine || engine === undefined ) {
 
-        engine = resolveEngines( 'joi', 'lov' );
-
-        if( !engine ) {
-
-            throw new Error( 'cannot find validation engine' );
-        }
+        throw new Error( 'missing required validation engine' );
     }
 
     return new SchemaBuilder( parser( engine ) );

--- a/test/src/alternatives.test.js
+++ b/test/src/alternatives.test.js
@@ -2,13 +2,13 @@
 
 /*jshint expr: true*/
 
-const AlternativesSchema = require( '../../lib/alternatives' );
+const AlternativesSchema = require( '../../src/alternatives' );
 
 const expect = require( 'chai' ).expect;
 
 const sinon = require( 'sinon' );
 
-describe( 'lib/alternatives', function() {
+describe( 'src/alternatives', function() {
 
     describe( 'AlternativesSchema', function() {
 

--- a/test/src/array.test.js
+++ b/test/src/array.test.js
@@ -2,13 +2,13 @@
 
 /*jshint expr: true*/
 
-const ArraySchema = require( '../../lib/array' );
+const ArraySchema = require( '../../src/array' );
 
 const expect = require( 'chai' ).expect;
 
 const sinon = require( 'sinon' );
 
-describe( 'lib/array', function() {
+describe( 'src/array', function() {
 
     describe( 'ArraySchema', function() {
 

--- a/test/src/base.test.js
+++ b/test/src/base.test.js
@@ -2,13 +2,13 @@
 
 /*jshint expr: true*/
 
-const BaseSchema = require( '../../lib/base' );
+const BaseSchema = require( '../../src/base' );
 
 const expect = require( 'chai' ).expect;
 
 const sinon = require( 'sinon' );
 
-describe( 'lib/base', function() {
+describe( 'src/base', function() {
 
     describe( 'BaseSchema', function() {
 

--- a/test/src/convert.test.js
+++ b/test/src/convert.test.js
@@ -2,11 +2,11 @@
 
 /*jshint expr: true*/
 
-const convert = require( '../../lib/convert' );
+const convert = require( '../../src/convert' );
 
 const expect = require( 'chai' ).expect;
 
-describe( 'lib/convert', function() {
+describe( 'src/convert', function() {
 
     [ 'min', 'max', 'length', 'greater', 'less', 'precision', 'multiple' ].forEach( function( key ) {
 

--- a/test/src/email.test.js
+++ b/test/src/email.test.js
@@ -2,13 +2,13 @@
 
 /*jshint expr: true*/
 
-const EmailSchema = require( '../../lib/email' );
+const EmailSchema = require( '../../src/email' );
 
 const expect = require( 'chai' ).expect;
 
 const sinon = require( 'sinon' );
 
-describe( 'lib/email', function() {
+describe( 'src/email', function() {
 
     describe( 'EmailSchema', function() {
 

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -14,9 +14,9 @@ const sinon = require( 'sinon' );
 
 const freshy = require( 'freshy' );
 
-const MODULE_PATH = '../../lib';
+const MODULE_PATH = '../../src';
 
-describe( 'lib/index', function() {
+describe( 'src/index', function() {
 
     let index;
 
@@ -35,19 +35,17 @@ describe( 'lib/index', function() {
 
     describe( '.builder', function() {
 
-        it( 'using defaults', function() {
+        it( 'use joi as engine', function() {
 
-            let builder = index.builder();
+            let builder = index.builder( joi );
 
             expect( builder.constructor.name ).to.equal( 'SchemaBuilder' );
             expect( builder.parser.engine ).to.equal( joi );
         });
 
-        it( 'use lov when joi is not present', function() {
+        it( 'use lov as engine', function() {
 
-            requireBlocker.block( 'joi' );
-
-            let builder = index.builder();
+            let builder = index.builder( lov );
 
             expect( builder.constructor.name ).to.equal( 'SchemaBuilder' );
             expect( builder.parser.engine ).to.equal( lov );
@@ -63,11 +61,9 @@ describe( 'lib/index', function() {
             expect( builder.parser.engine ).to.equal( customEngine );
         });
 
-        it( 'fail: when engines do not exist', function() {
+        it( 'fail: when no engine passed in', function() {
 
-            requireBlocker.block( 'joi', 'lov' );
-
-            expect( index.builder.bind( null ) ).to.throw( 'cannot find validation engine' );
+            expect( index.builder.bind( null ) ).to.throw( 'missing required validation engine' );
         });
     });
 

--- a/test/src/object.test.js
+++ b/test/src/object.test.js
@@ -2,13 +2,13 @@
 
 /*jshint expr: true*/
 
-const ObjectSchema = require( '../../lib/object' );
+const ObjectSchema = require( '../../src/object' );
 
 const expect = require( 'chai' ).expect;
 
 const sinon = require( 'sinon' );
 
-describe( 'lib/object', function() {
+describe( 'src/object', function() {
 
     describe( 'ObjectSchema', function() {
 

--- a/test/src/parser.test.js
+++ b/test/src/parser.test.js
@@ -2,13 +2,13 @@
 
 /*jshint expr: true*/
 
-const Parser = require( '../../lib/parser' );
+const Parser = require( '../../src/parser' );
 
 const expect = require( 'chai' ).expect;
 
 const sinon = require( 'sinon' );
 
-describe( 'lib/parser', function() {
+describe( 'src/parser', function() {
 
     let engine;
 

--- a/test/src/string.test.js
+++ b/test/src/string.test.js
@@ -2,13 +2,13 @@
 
 /*jshint expr: true*/
 
-const StringSchema = require( '../../lib/string' );
+const StringSchema = require( '../../src/string' );
 
 const expect = require( 'chai' ).expect;
 
 const sinon = require( 'sinon' );
 
-describe( 'lib/string', function() {
+describe( 'src/string', function() {
 
     describe( 'StringSchema', function() {
 

--- a/test/src/uuid.test.js
+++ b/test/src/uuid.test.js
@@ -2,7 +2,7 @@
 
 /*jshint expr: true*/
 
-const UUIDSchema = require( '../../lib/uuid' );
+const UUIDSchema = require( '../../src/uuid' );
 
 const expect = require( 'chai' ).expect;
 
@@ -10,7 +10,7 @@ const sinon = require( 'sinon' );
 
 const CONTROL_UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
-describe( 'lib/uuid', function() {
+describe( 'src/uuid', function() {
 
     describe( 'uuidSchema', function() {
 


### PR DESCRIPTION
- Updated index.js to remove resolving engines from requires() - forcing engine to be passed in
- Updated index.test.js base on index.js changes
- Updated pathing for all tests to include from src, not lib